### PR TITLE
Create FAQ for people to freely add to

### DIFF
--- a/FAQ.md
+++ b/FAQ.md
@@ -2,6 +2,17 @@ AgileVentures
 FAQ
 ===
 
+##Contributing to this FAQ
+Please add your question(s) and answers!  Did you have questions when you first joined AgileVentures (or maybe you still do)? Do you have answers?  Help us by freely adding to this document.
+
+This document is in its early stages.  We want to capture as many questions and answers as possible.  If you've had a *question* about AgileVentures, or if you can *answer* something, please _do_ edit this document.  If you are not sure if your information duplicates information, just note make a note about that: _"(This may be a duplicate of ...)"_.  If your answer contradicts another answer, please note the contradiction *_and_* *file an issue* so that others are aware of the contradiction and can help to resolve it.
+
+
+It's not yet clear how to best organize this information.  Make your best guess, and then as more information is added to this document, we'll evaluate and organize things.
+
+This information may later be put into a database and displayed on the AgileVentures site (a.k.a. WebSiteOne (WSO)).  For now, we just want to gather as much information as possible.
+
+
 ##Joining a Project
 
 
@@ -28,11 +39,3 @@ FAQ
 ##Projects for Non-Profits
 
 
-##Contributing to this FAQ
-This document is in its early stages.  We want to capture as many questions and answers as possible.  If you've had a *question* about AgileVentures, or if you can *answer* something, please _do_ edit this document.  If you are not sure if your information duplicates information, just note make a note about that: _"(This may be a duplicate of ...)"_.  If your answer contradicts another answer, please note the contradiction *_and_* *file an issue* so that others are aware of the contradiction and can help to resolve it.
-
-
-
-It's not yet clear how to best organize this information.  Make your best guess, and then as more information is added to this document, we'll evaluate and organize things.
-
-This information may later be put into a database and displayed on the AgileVentures site (a.k.a. WebSiteOne (WSO)).  For now, we just want to gather as much information as possible.

--- a/FAQ.md
+++ b/FAQ.md
@@ -1,0 +1,38 @@
+AgileVentures
+FAQ
+===
+
+##Joining a Project
+
+
+##Discussing Things on Slack
+
+
+##Pair Programming
+
+
+##Scrums
+
+
+##Events (Hangouts)
+
+
+##About AgileVentures (Vision, History)
+
+
+##Premium Membership
+
+
+##Sponsors
+
+##Projects for Non-Profits
+
+
+##Contributing to this FAQ
+This document is in its early stages.  We want to capture as many questions and answers as possible.  If you've had a *question* about AgileVentures, or if you can *answer* something, please _do_ edit this document.  If you are not sure if your information duplicates information, just note make a note about that: _"(This may be a duplicate of ...)"_.  If your answer contradicts another answer, please note the contradiction *_and_* *file an issue* so that others are aware of the contradiction and can help to resolve it.
+
+
+
+It's not yet clear how to best organize this information.  Make your best guess, and then as more information is added to this document, we'll evaluate and organize things.
+
+This information may later be put into a database and displayed on the AgileVentures site (a.k.a. WebSiteOne (WSO)).  For now, we just want to gather as much information as possible.


### PR DESCRIPTION
The start of a FAQ for AgileVentures.  There's clearly a need for a FAQ, and people have questions they had (or still have) and answers.  This is document that people can freely edit and add their questions and answers.

The goal is to just _capture_ as much information as possible.  People should add freely to this right now: questions they've had and/or answers they know.

We shouldn't worry too much about formatting or organization at the moment.  As information is contributed, we can format and organize.

(Ultimately, the information should be put into a database so that it can be searched, tagged, etc.  And then the FAQ can be a page served up by WebSiteOne.  But for now, we just need to collect the info.)