### PR TITLE
Create 1-duplicate_remover--WSO_export_update-ee_All_contacts.rb

### DIFF
--- a/howto/email_lists/1-duplicate_remover--WSO_export_update-ee_All_contacts.rb
+++ b/howto/email_lists/1-duplicate_remover--WSO_export_update-ee_All_contacts.rb
@@ -1,0 +1,17 @@
+File.open("New-Emails-WSO-export-update-2017-08-22.csv", "w") do |dest_file|
+
+  final_large_file = []
+
+  large_file_1 = File.read("WSO-export-update-2017-08-22.txt").split("\n")
+  large_file_1.uniq!
+
+  large_file_2 = File.read("elasticemail-All_Contacts-4668--2017-08-22.txt").split("\n")
+
+  final_large_file = large_file_1 - large_file_2
+
+
+  final_large_file.each do |line|
+    dest_file.puts line
+  end
+
+end


### PR DESCRIPTION
Ruby script 1 of 4 that I use in updating email list contacts from WSO and WS2 for the newsletter.

Steps are in `../monthly_newsletter.md`

Line 6 should be unnecessary in all 4 scripts:

` large_file_1.uniq!`

 It's a harmless artifact from when I was writing and testing the scripts.